### PR TITLE
Fix mps_uniform on python 3.9 and above

### DIFF
--- a/evoMPS/mps_uniform.py
+++ b/evoMPS/mps_uniform.py
@@ -15,7 +15,11 @@ from . import tdvp_common as tm
 from . import matmul as m
 from . import mps_uniform_pinv as pinv
 import math as ma
-from fractions import gcd
+try:
+    from fractions import gcd
+except ImportError:
+    from math import gcd
+
 import logging
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
The `gcd` method in the `fractions` package has been deprecated since
python 3.5 and has been removed in python 3.9.  The `math` package
provides a replacement on python 3.5 and above.

@amilsted I'm aware you're probably not touching this anymore. But I thought it might be useful for others, even if not merged.